### PR TITLE
Walks up from Galleyfile to find package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "repository": "crashlytics/galley-cli",
   "dependencies": {
+    "chalk": "^1.1.1",
     "check-dependencies": "^0.9.5",
     "findup-sync": "^0.2.1",
     "resolve": "^1.1.6"


### PR DESCRIPTION
Makes galley-cli more tolerant of being run from the galley acceptance
directory.

Also adds chalk to liven up messaging.
